### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/doctales/org.doctales.terminology.png?label=ready&title=Ready)](https://waffle.io/doctales/org.doctales.terminology)
 ![DOCTALES Logo](https://doctales.github.io/images/doctales-logo-without-subtitle.svg)
 
 - - - -


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/doctales/org.doctales.terminology

This was requested by a real person (user xephon2) on waffle.io, we're not trying to spam you.