### PR TITLE
Use new way of invoking xslt task defined in DITA OT pipeline

### DIFF
--- a/build_dita2tbx-basic_template.xml
+++ b/build_dita2tbx-basic_template.xml
@@ -15,21 +15,18 @@
     </target>
     
     <target name="dita.topics.html.tbx-basic" description="Build XHTML output from dita inner and outer topics,which will adjust the directory.">
-        <xslt basedir="${dita.temp.dir}"
-            destdir="${output.dir}"
-            includesfile="${dita.temp.dir}${file.separator}${fullditatopicfile}"
-            reloadstylesheet="${dita.xhtml.reloadstylesheet}"
-            classpathref="dost.class.path"
-            extension=".tbx"
-            style="${dita.plugin.org.doctales.terminology.dir}/xsl/terminology2tbx-basic.xsl"
-            filenameparameter="FILENAME" 
-            filedirparameter="FILEDIR">
-            <param name="sourceLanguage" expression="${args.source.language}" if="args.source.language"/>
-            <param name="targetLanguage" expression="${args.target.language}" if="args.target.language"/>
-            <excludesfile name="${dita.temp.dir}${file.separator}${resourceonlyfile}" if="resourceonlyfile"></excludesfile>
-            <includesfile name="${dita.temp.dir}${file.separator}${chunkedtopicfile}" if="chunkedtopicfile"></includesfile>
-            <xmlcatalog refid="dita.catalog"/>
-        </xslt>
+        <pipeline>
+            <xslt 
+                destdir="${output.dir}"
+                reloadstylesheet="${dita.xhtml.reloadstylesheet}"
+                extension=".tbx"
+                style="${dita.plugin.org.doctales.terminology.dir}/xsl/terminology2tbx-basic.xsl">
+                <ditafileset format="dita" processingRole="normal"/>
+                <param name="sourceLanguage" expression="${args.source.language}" if="args.source.language"/>
+                <param name="targetLanguage" expression="${args.target.language}" if="args.target.language"/>
+                <xmlcatalog refid="dita.catalog"/>
+            </xslt>
+        </pipeline>
         <basename property="tbx-basic" file="${args.input}" suffix=".ditamap"/>
         <delete>
             <fileset dir="${output.dir}" >

--- a/build_dita2tbx-min_template.xml
+++ b/build_dita2tbx-min_template.xml
@@ -15,21 +15,18 @@
     </target>
     
     <target name="dita.topics.html.tbx-min" description="Build XHTML output from dita inner and outer topics,which will adjust the directory.">
-        <xslt basedir="${dita.temp.dir}"
-            destdir="${output.dir}"
-            includesfile="${dita.temp.dir}${file.separator}${fullditatopicfile}"
-            reloadstylesheet="${dita.xhtml.reloadstylesheet}"
-            classpathref="dost.class.path"
-            extension=".tbxm"
-            style="${dita.plugin.org.doctales.terminology.dir}/xsl/terminology2tbx-min.xsl"
-            filenameparameter="FILENAME" 
-            filedirparameter="FILEDIR">
-            <param name="sourceLanguage" expression="${args.source.language}" if="args.source.language"/>
-            <param name="targetLanguage" expression="${args.target.language}" if="args.target.language"/>
-            <excludesfile name="${dita.temp.dir}${file.separator}${resourceonlyfile}" if="resourceonlyfile"></excludesfile>
-            <includesfile name="${dita.temp.dir}${file.separator}${chunkedtopicfile}" if="chunkedtopicfile"></includesfile>
-            <xmlcatalog refid="dita.catalog"/>
-        </xslt>
+        <pipeline>
+            <xslt 
+                destdir="${output.dir}"
+                reloadstylesheet="${dita.xhtml.reloadstylesheet}"
+                extension=".tbxm"
+                style="${dita.plugin.org.doctales.terminology.dir}/xsl/terminology2tbx-min.xsl">
+                <ditafileset format="dita" processingRole="normal"/>
+                <param name="sourceLanguage" expression="${args.source.language}" if="args.source.language"/>
+                <param name="targetLanguage" expression="${args.target.language}" if="args.target.language"/>
+                <xmlcatalog refid="dita.catalog"/>
+            </xslt>
+        </pipeline>
         <basename property="tbx-min" file="${args.input}" suffix=".ditamap"/>
         <delete>
             <fileset dir="${output.dir}" >

--- a/build_dita2termchecker-dita_template.xml
+++ b/build_dita2termchecker-dita_template.xml
@@ -18,20 +18,17 @@
     </target>
     
     <target name="termchecker-dita.create-schematron" description="Create a Schematron termchecker for XLIFF">
-        <xslt basedir="${dita.temp.dir}"
+        <pipeline>
+        <xslt 
             destdir="${output.dir}"
-            includesfile="${dita.temp.dir}${file.separator}${fullditatopicfile}"
             reloadstylesheet="${dita.xhtml.reloadstylesheet}"
-            classpathref="dost.class.path"
             extension="-DITA-${args.language}.sch"
-            style="${dita.plugin.org.doctales.terminology.dir}/xsl/terminology2termchecker-dita.xsl"
-            filenameparameter="FILENAME" 
-            filedirparameter="FILEDIR">
+            style="${dita.plugin.org.doctales.terminology.dir}/xsl/terminology2termchecker-dita.xsl">
+            <ditafileset format="dita" processingRole="normal"/>
             <param name="language" expression="${args.language}" if="args.language"/>
-            <excludesfile name="${dita.temp.dir}${file.separator}${resourceonlyfile}" if="resourceonlyfile"/>
-            <includesfile name="${dita.temp.dir}${file.separator}${chunkedtopicfile}" if="chunkedtopicfile"/>
             <xmlcatalog refid="dita.catalog"/>
         </xslt>
+        </pipeline>
         <basename property="schematronFile" file="${args.input}" suffix=".ditamap"/>
         <delete>
             <fileset dir="${output.dir}" >

--- a/build_dita2termchecker-xliff_template.xml
+++ b/build_dita2termchecker-xliff_template.xml
@@ -18,21 +18,18 @@
     </target>
     
     <target name="termchecker-xliff.create-schematron" description="Create a Schematron termchecker for XLIFF">
-        <xslt basedir="${dita.temp.dir}"
-            destdir="${output.dir}"
-            includesfile="${dita.temp.dir}${file.separator}${fullditatopicfile}"
-            reloadstylesheet="${dita.xhtml.reloadstylesheet}"
-            classpathref="dost.class.path"
-            extension="-XLIFF-${args.language}.sch"
-            style="${dita.plugin.org.doctales.terminology.dir}/xsl/terminology2termchecker-xliff.xsl"
-            filenameparameter="FILENAME" 
-            filedirparameter="FILEDIR">
-            <param name="language" expression="${args.language}" if="args.language"/>
-            <param name="checkElements" expression="${args.check.elements}" if="args.check.elements"/>
-            <excludesfile name="${dita.temp.dir}${file.separator}${resourceonlyfile}" if="resourceonlyfile"/>
-            <includesfile name="${dita.temp.dir}${file.separator}${chunkedtopicfile}" if="chunkedtopicfile"/>
-            <xmlcatalog refid="dita.catalog"/>
-        </xslt>
+        <pipeline>
+            <xslt 
+                destdir="${output.dir}"
+                reloadstylesheet="${dita.xhtml.reloadstylesheet}"
+                extension="-XLIFF-${args.language}.sch"
+                style="${dita.plugin.org.doctales.terminology.dir}/xsl/terminology2termchecker-xliff.xsl">
+                <ditafileset format="dita" processingRole="normal"/>
+                <param name="language" expression="${args.language}" if="args.language"/>
+                <param name="checkElements" expression="${args.check.elements}" if="args.check.elements"/>
+                <xmlcatalog refid="dita.catalog"/>
+            </xslt>
+        </pipeline>
         <basename property="schematronFile" file="${args.input}" suffix=".ditamap"/>
         <delete>
             <fileset dir="${output.dir}" >


### PR DESCRIPTION
Made build files compatible with DITA OT 3.6 which removed certain deprecated parameters.
I only tested the changes in the "build_dita2termchecker-dita_template.xml" and they seemed to work. I'm not sure if this still works with DITA OT 2.3, I did not test this.

Signed-off-by: Radu Coravu <radu_coravu@sync.ro>